### PR TITLE
BAC-I3016: release for API 3.5.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,5 +34,5 @@ curl -X GET \
 ```
 
 ::: tip VERSION NOTE
-Arable API 3.4.0 is now commercially released. See our changelog for release changes.
+Arable API 3.5.0 is now commercially released. See our changelog for release changes.
 :::

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -11,7 +11,7 @@ All data is sent and received as JSON.
 
 | API Version | Release Date | Software Version |
 |---|---|---|
-|3.5.0|2022-07-27|[3.40.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.40.0)|
+|3.5.0|2022-07-28|[3.40.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.40.0)|
 |3.4.0|2022-03-31|[3.36.5](https://api.arable.cloud/api/v2/doc#section/Changelog/3.36.5)|
 |3.3.1|2021-12-20|[3.33.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.33.0)|
 |3.3.0|2021-12-13|[3.32.1](https://api.arable.cloud/api/v2/doc#section/Changelog/3.32.1)|

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -11,7 +11,7 @@ All data is sent and received as JSON.
 
 | API Version | Release Date | Software Version |
 |---|---|---|
-|3.5.0|2022-08-03|[3.40.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.40.0)|
+|3.5.0|2022-07-27|[3.40.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.40.0)|
 |3.4.0|2022-03-31|[3.36.5](https://api.arable.cloud/api/v2/doc#section/Changelog/3.36.5)|
 |3.3.1|2021-12-20|[3.33.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.33.0)|
 |3.3.0|2021-12-13|[3.32.1](https://api.arable.cloud/api/v2/doc#section/Changelog/3.32.1)|

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -11,6 +11,7 @@ All data is sent and received as JSON.
 
 | API Version | Release Date | Software Version |
 |---|---|---|
+|3.5.0|2022-08-03|[3.40.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.40.0)|
 |3.4.0|2022-03-31|[3.36.5](https://api.arable.cloud/api/v2/doc#section/Changelog/3.36.5)|
 |3.3.1|2021-12-20|[3.33.0](https://api.arable.cloud/api/v2/doc#section/Changelog/3.33.0)|
 |3.3.0|2021-12-13|[3.32.1](https://api.arable.cloud/api/v2/doc#section/Changelog/3.32.1)|


### PR DESCRIPTION
# NOTE: HOLD TILL RELEASE DAY

The change validated in local.